### PR TITLE
Properly render address data in POI details view

### DIFF
--- a/CityZenApp/app/src/main/java/com/cityzen/cityzen/Fragments/PoiDetailsFragment.java
+++ b/CityZenApp/app/src/main/java/com/cityzen/cityzen/Fragments/PoiDetailsFragment.java
@@ -71,8 +71,7 @@ public class PoiDetailsFragment extends DialogFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        View rootView = inflater.inflate(R.layout.fragment_poi_details, container, false);
-        return rootView;
+        return inflater.inflate(R.layout.fragment_poi_details, container, false);
     }
 
     @Override
@@ -105,15 +104,15 @@ public class PoiDetailsFragment extends DialogFragment {
 
 
     private void viewSetup() {
-        TextView osmCopyright = (TextView) getDialog().findViewById(R.id.osmCopyright);
+        TextView osmCopyright = getDialog().findViewById(R.id.osmCopyright);
         osmCopyright.setText(Html.fromHtml(getString(R.string.osm_copyright)));
-        poiDialogDirectionsButton = (Button) getDialog().findViewById(R.id.poiDialogDirectionsButton);
-        favoriteImageButton = (ImageButton) getDialog().findViewById(R.id.poiDialogFavorite);
-        poiDialogEdit = (ImageButton) getDialog().findViewById(R.id.poiDialogEdit);
-        poiTitleDialog = (TextView) getDialog().findViewById(R.id.poiTitleDialog);
-        poiDialogAddress = (TextView) getDialog().findViewById(R.id.poiDialogAddress);
-        poiDialogContent = (LinearLayout) getDialog().findViewById(R.id.poiDialogContent);
-        ImageButton poiDialogClose = (ImageButton) getDialog().findViewById(R.id.poiDialogClose);
+        poiDialogDirectionsButton = getDialog().findViewById(R.id.poiDialogDirectionsButton);
+        favoriteImageButton = getDialog().findViewById(R.id.poiDialogFavorite);
+        poiDialogEdit = getDialog().findViewById(R.id.poiDialogEdit);
+        poiTitleDialog = getDialog().findViewById(R.id.poiTitleDialog);
+        poiDialogAddress = getDialog().findViewById(R.id.poiDialogAddress);
+        poiDialogContent = getDialog().findViewById(R.id.poiDialogContent);
+        ImageButton poiDialogClose = getDialog().findViewById(R.id.poiDialogClose);
         poiDialogClose.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -161,7 +160,7 @@ public class PoiDetailsFragment extends DialogFragment {
 
     private void loadDataToUI() {
         poiTitleDialog.setText(POI.getPoiName());
-        poiDialogAddress.setText(POI.getFullName());
+        poiDialogAddress.setText(createAddressDisplayString(POI));
         //display tags to view
         if (POI.getTags() != null)
             for (Map.Entry<String, String> tag : POI.getTags().entrySet()) {
@@ -183,6 +182,31 @@ public class PoiDetailsFragment extends DialogFragment {
                             ));
             }
         updateFavoriteButton();
+    }
+
+    private String createAddressDisplayString(ParcelablePOI poi) {
+        String address = "";
+        if (poi.getTags().containsKey("addr:street")) {
+            if (poi.getTags().containsKey("addr:housenumber")) {
+                address += poi.getTags().get("addr:street") + " " + poi.getTags().get("addr:housenumber");
+            } else {
+                address = poi.getTags().get("addr:street");
+            }
+        }
+
+        if ((poi.getTags().containsKey("addr:postcode") || poi.getTags().containsKey("addr:city")) && address.length() > 0) {
+            address += "\n";
+        }
+
+        if (poi.getTags().containsKey("addr:postcode") && poi.getTags().containsKey("addr:city")) {
+            address += poi.getTags().get("addr:postcode") + " " + poi.getTags().get("addr:city");
+        } else if (poi.getTags().containsKey("addr:postcode")) {
+            address += poi.getTags().get("addr:postcode");
+        } else if (poi.getTags().containsKey("addr:city")) {
+            address += poi.getTags().get("addr:city");
+        }
+
+        return address;
     }
 
     private void updateFavoriteButton() {

--- a/CityZenApp/app/src/main/java/com/cityzen/cityzen/Models/ParcelablePOI.java
+++ b/CityZenApp/app/src/main/java/com/cityzen/cityzen/Models/ParcelablePOI.java
@@ -42,7 +42,7 @@ public class ParcelablePOI implements Parcelable {
      */
 
     private String poiName;             //POI name
-    private String fullName = "";             //POI name + address
+    private String fullName = "";       //POI name + address
     private String osmType = "";        //e.g. node
     private String poiClassName = "";   //e.g. amenity
     private String poiClassType = "";   //e.g. bar

--- a/CityZenApp/app/src/main/java/com/cityzen/cityzen/Utils/MapUtils/Search/nominatimparser/Place.java
+++ b/CityZenApp/app/src/main/java/com/cityzen/cityzen/Utils/MapUtils/Search/nominatimparser/Place.java
@@ -11,7 +11,7 @@ public class Place extends Adress {
     private float importance;
     private String license, osm_type, display_name, entityClass, type;
     private BoundingBox boundingBox;
-    private Map<String, String> tags = new HashMap<String, String>();
+    private Map<String, String> tags = new HashMap<>();
 
     public Place(long place_id, long osm_id, double lat, double lon, float importance, String license, String osm_type, String display_name, String entityClass, String type, BoundingBox boundingBox, Map<String, String> tags) {
         super(display_name, android.R.mipmap.sym_def_app_icon, lat, lon);

--- a/CityZenApp/app/src/main/res/layout/fragment_poi_details.xml
+++ b/CityZenApp/app/src/main/res/layout/fragment_poi_details.xml
@@ -20,15 +20,13 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
-                android:layout_marginBottom="16dp"
-                android:layout_marginTop="16dp"
+                android:layout_margin="16dp"
                 android:gravity="center_vertical">
 
                 <ImageButton
                     android:id="@+id/poiDialogClose"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="16dp"
                     android:background="@android:color/transparent"
                     app:srcCompat="@drawable/ic_close_dialog" />
 
@@ -43,7 +41,7 @@
                     android:ellipsize="end"
                     android:maxLines="1"
                     android:scrollHorizontally="true"
-                    android:text="Poi title"
+                    tools:text="Poi title"
                     android:textAlignment="center"
                     android:textSize="18sp" />
 
@@ -64,7 +62,6 @@
                     android:layout_height="wrap_content"
                     android:layout_alignParentEnd="true"
                     android:layout_alignParentRight="true"
-                    android:layout_marginRight="16dp"
                     android:background="@android:color/transparent"
                     app:srcCompat="@drawable/ic_mode_edit_dialog" />
             </RelativeLayout>
@@ -94,7 +91,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_weight="0.5"
-                        android:text="Fast Food" />
+                        tools:text="Fast Food" />
                 </LinearLayout>
 
 


### PR DESCRIPTION
Fixes #32 
by relying on the poi tags instead of the `full_name` field which e.g. doesn't contain house numbers.

![device-2018-03-04-125146](https://user-images.githubusercontent.com/1315170/36945190-d1d36e06-1faa-11e8-8f68-8769618fd85d.png)

cc @rskikuli @sidorelauku @AnXh3L0 