### PR TITLE
fix shopping mal icon

### DIFF
--- a/CityZenApp/app/src/main/res/values/arrays.xml
+++ b/CityZenApp/app/src/main/res/values/arrays.xml
@@ -61,7 +61,7 @@
         <item>@drawable/ic_local_pharmacy_white</item>
         <item>@drawable/ic_local_post_office</item>
         <item>@drawable/ic_restaurant_white</item>
-        <item>@drawable/ic_room_service_white_24dp</item>
+        <item>@drawable/ic_local_mall_white_24dp</item>
         <item>@drawable/ic_nature_people_white</item>
         <item>@drawable/ic_directions_bus_white</item>
     </array>


### PR DESCRIPTION
I accidentally assigned the wrong icon to the shopping category. This PR fixes that.
![device-2018-03-04-204220](https://user-images.githubusercontent.com/1315170/36949727-8e581b80-1fec-11e8-8eba-8898be448659.png)
