### PR TITLE
fix background color of list that use the custom dividers

### DIFF
--- a/CityZenApp/app/src/main/res/layout/fragment_favorites.xml
+++ b/CityZenApp/app/src/main/res/layout/fragment_favorites.xml
@@ -10,7 +10,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_alignParentBottom="true"
-        android:layout_centerHorizontal="true" />
+        android:layout_centerHorizontal="true"
+        android:background="@color/colorWhite"/>
 
     <LinearLayout
         android:id="@+id/emptyFavorites"

--- a/CityZenApp/app/src/main/res/layout/fragment_search.xml
+++ b/CityZenApp/app/src/main/res/layout/fragment_search.xml
@@ -72,7 +72,8 @@
         android:layout_height="match_parent"
         android:layout_alignParentBottom="true"
         android:layout_below="@+id/filterPoiListContainer"
-        android:layout_centerHorizontal="true" />
+        android:layout_centerHorizontal="true"
+        android:background="@color/colorWhite"/>
 
     <LinearLayout
         android:id="@+id/emptySearchResult"


### PR DESCRIPTION
The recycler views didn't have a background color set, so for the lists that use the divider with the padding (favorites, search results) the super-light-grey color of the background was shining through while the idea behind the divider was to have a padding as large as the list item icons.

By setting the views background color this visual glitch (hard to see except with zoomed in screenshots) is fixed.